### PR TITLE
Update risc0 zkvm to 0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
- "bonsai-sdk 0.1.0",
+ "bonsai-sdk 0.2.0 (git+https://github.com/risc0/risc0?branch=main)",
  "bonsai-starter-methods",
  "bytemuck",
  "clap",
@@ -340,8 +340,8 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "0.1.0"
-source = "git+https://github.com/risc0/risc0?branch=main#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+version = "0.2.0"
+source = "git+https://github.com/risc0/risc0?branch=main#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "reqwest",
  "serde",
@@ -351,7 +351,7 @@ dependencies = [
 [[package]]
 name = "bonsai-sdk"
 version = "0.2.0"
-source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
+source = "git+https://github.com/risc0/risc0?branch=release-0.16#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "reqwest",
  "serde",
@@ -445,18 +445,18 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.4"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
 dependencies = [
  "serde",
 ]
@@ -618,9 +618,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "const-oid"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6340df57935414636969091153f35f68d9f00bbc8fb4a9c6054706c213e6c6bc"
+checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
 name = "constant_time_eq"
@@ -1028,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
@@ -1928,7 +1928,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls 0.21.3",
+ "rustls 0.21.5",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -2091,7 +2091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.3",
+ "rustix 0.38.4",
  "windows-sys",
 ]
 
@@ -3016,18 +3016,18 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.7.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -3038,9 +3038,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "reqwest"
@@ -3067,7 +3067,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.3",
+ "rustls 0.21.5",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -3132,7 +3132,7 @@ dependencies = [
 [[package]]
 name = "risc0-build"
 version = "0.16.1"
-source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
+source = "git+https://github.com/risc0/risc0?branch=release-0.16#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "cargo_metadata",
  "directories",
@@ -3149,7 +3149,7 @@ dependencies = [
 [[package]]
 name = "risc0-build-kernel"
 version = "0.16.1"
-source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
+source = "git+https://github.com/risc0/risc0?branch=release-0.16#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "cc",
  "directories",
@@ -3162,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "risc0-circuit-rv32im"
 version = "0.16.1"
-source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
+source = "git+https://github.com/risc0/risc0?branch=release-0.16#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "anyhow",
  "log",
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "risc0-circuit-rv32im-sys"
 version = "0.16.1"
-source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
+source = "git+https://github.com/risc0/risc0?branch=release-0.16#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3190,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "risc0-core"
 version = "0.16.1"
-source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
+source = "git+https://github.com/risc0/risc0?branch=release-0.16#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -3199,7 +3199,7 @@ dependencies = [
 [[package]]
 name = "risc0-sys"
 version = "0.16.1"
-source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
+source = "git+https://github.com/risc0/risc0?branch=release-0.16#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "cc",
  "glob",
@@ -3210,7 +3210,7 @@ dependencies = [
 [[package]]
 name = "risc0-zkp"
 version = "0.16.1"
-source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
+source = "git+https://github.com/risc0/risc0?branch=release-0.16#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3237,11 +3237,11 @@ dependencies = [
 [[package]]
 name = "risc0-zkvm"
 version = "0.16.1"
-source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
+source = "git+https://github.com/risc0/risc0?branch=release-0.16#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "anyhow",
  "bincode",
- "bonsai-sdk 0.2.0",
+ "bonsai-sdk 0.2.0 (git+https://github.com/risc0/risc0?branch=release-0.16)",
  "bytemuck",
  "cfg-if",
  "crypto-bigint 0.5.2",
@@ -3272,7 +3272,7 @@ dependencies = [
 [[package]]
 name = "risc0-zkvm-platform"
 version = "0.16.1"
-source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
+source = "git+https://github.com/risc0/risc0?branch=release-0.16#0d02111b2f84a53cf6198a0064086b281ed0f749"
 
 [[package]]
 name = "rlp"
@@ -3426,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -3451,9 +3451,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.3"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring",
@@ -3687,9 +3687,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
+checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
 dependencies = [
  "itoa",
  "ryu",
@@ -4125,7 +4125,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.3",
+ "rustls 0.21.5",
  "tokio",
 ]
 
@@ -4137,7 +4137,7 @@ checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.21.3",
+ "rustls 0.21.5",
  "tokio",
  "tokio-rustls 0.24.1",
  "tungstenite",
@@ -4181,9 +4181,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.12"
+version = "0.19.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
+checksum = "5f8751d9c1b03c6500c387e96f81f815a4f8e72d142d2d4a9ffa6fedd51ddee7"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -4259,7 +4259,7 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "rustls 0.21.3",
+ "rustls 0.21.5",
  "sha1",
  "thiserror",
  "url",
@@ -4275,9 +4275,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "typetag"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092e9b66a97c5f12e64f2d9c08c27d80342ff1ecde1d92288f939f55f5f1bcb3"
+checksum = "7a66aafcfb982bf1f9a28755ac6bcbdcd4631ff516cb038fa61299201ebb4364"
 dependencies = [
  "erased-serde",
  "inventory",
@@ -4288,9 +4288,9 @@ dependencies = [
 
 [[package]]
 name = "typetag-impl"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae02a82d555be0636f3157d90b6e0ccc6eda4cbc2af123187682143ce3035f1"
+checksum = "d836cd032f71d90cbaa3c1f85ce84266af23659766d8c0b1c4c6524a0fb4c36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4624,9 +4624,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.9"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
+checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
- "bonsai-sdk",
+ "bonsai-sdk 0.1.0",
  "bonsai-starter-methods",
  "bytemuck",
  "clap",
@@ -342,6 +342,16 @@ dependencies = [
 name = "bonsai-sdk"
 version = "0.1.0"
 source = "git+https://github.com/risc0/risc0?branch=main#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+dependencies = [
+ "reqwest",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "bonsai-sdk"
+version = "0.2.0"
+source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "reqwest",
  "serde",
@@ -3121,8 +3131,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "0.15.0"
-source = "git+https://github.com/risc0/risc0?rev=b35e1faa37fb4b60cf8dd849cf46b14d1713c881#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+version = "0.16.1"
+source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "cargo_metadata",
  "directories",
@@ -3138,8 +3148,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "0.15.0"
-source = "git+https://github.com/risc0/risc0?rev=b35e1faa37fb4b60cf8dd849cf46b14d1713c881#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+version = "0.16.1"
+source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "cc",
  "directories",
@@ -3151,8 +3161,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.15.0"
-source = "git+https://github.com/risc0/risc0?rev=b35e1faa37fb4b60cf8dd849cf46b14d1713c881#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+version = "0.16.1"
+source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "anyhow",
  "log",
@@ -3168,8 +3178,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "0.15.0"
-source = "git+https://github.com/risc0/risc0?rev=b35e1faa37fb4b60cf8dd849cf46b14d1713c881#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+version = "0.16.1"
+source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3179,8 +3189,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.15.0"
-source = "git+https://github.com/risc0/risc0?rev=b35e1faa37fb4b60cf8dd849cf46b14d1713c881#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+version = "0.16.1"
+source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -3188,8 +3198,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "0.15.0"
-source = "git+https://github.com/risc0/risc0?rev=b35e1faa37fb4b60cf8dd849cf46b14d1713c881#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+version = "0.16.1"
+source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "cc",
  "glob",
@@ -3199,8 +3209,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.15.0"
-source = "git+https://github.com/risc0/risc0?rev=b35e1faa37fb4b60cf8dd849cf46b14d1713c881#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+version = "0.16.1"
+source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3220,16 +3230,18 @@ dependencies = [
  "risc0-zkvm-platform",
  "serde",
  "sha2 0.10.7",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.15.0"
-source = "git+https://github.com/risc0/risc0?rev=b35e1faa37fb4b60cf8dd849cf46b14d1713c881#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+version = "0.16.1"
+source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "anyhow",
  "bincode",
+ "bonsai-sdk 0.2.0",
  "bytemuck",
  "cfg-if",
  "crypto-bigint 0.5.2",
@@ -3252,14 +3264,15 @@ dependencies = [
  "rrs-lib",
  "serde",
  "sha2 0.10.7",
+ "thiserror",
  "tracing",
  "typetag",
 ]
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.15.0"
-source = "git+https://github.com/risc0/risc0?rev=b35e1faa37fb4b60cf8dd849cf46b14d1713c881#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+version = "0.16.1"
+source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
 
 [[package]]
 name = "rlp"

--- a/methods/Cargo.toml
+++ b/methods/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 methods = ["guest"]
 
 [build-dependencies]
-risc0-build = { git = "https://github.com/risc0/risc0", rev = "0d02111b2f84a53cf6198a0064086b281ed0f749", features = ["guest-list"] }
+risc0-build = { git = "https://github.com/risc0/risc0", branch = "release-0.16", features = ["guest-list"] }
 
 [dependencies]
-risc0-build = { git = "https://github.com/risc0/risc0", rev = "0d02111b2f84a53cf6198a0064086b281ed0f749", features = ["guest-list"] }
-risc0-zkvm = { git = "https://github.com/risc0/risc0", rev = "0d02111b2f84a53cf6198a0064086b281ed0f749" }
+risc0-build = { git = "https://github.com/risc0/risc0", branch = "release-0.16", features = ["guest-list"] }
+risc0-zkvm = { git = "https://github.com/risc0/risc0", branch = "release-0.16" }

--- a/methods/Cargo.toml
+++ b/methods/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 methods = ["guest"]
 
 [build-dependencies]
-risc0-build = { git = "https://github.com/risc0/risc0", rev = "b35e1faa37fb4b60cf8dd849cf46b14d1713c881", features = ["guest-list"] }
+risc0-build = { git = "https://github.com/risc0/risc0", rev = "0d02111b2f84a53cf6198a0064086b281ed0f749", features = ["guest-list"] }
 
 [dependencies]
-risc0-build = { git = "https://github.com/risc0/risc0", rev = "b35e1faa37fb4b60cf8dd849cf46b14d1713c881", features = ["guest-list"] }
-risc0-zkvm = { git = "https://github.com/risc0/risc0", rev = "b35e1faa37fb4b60cf8dd849cf46b14d1713c881" }
+risc0-build = { git = "https://github.com/risc0/risc0", rev = "0d02111b2f84a53cf6198a0064086b281ed0f749", features = ["guest-list"] }
+risc0-zkvm = { git = "https://github.com/risc0/risc0", rev = "0d02111b2f84a53cf6198a0064086b281ed0f749" }

--- a/methods/guest/Cargo.lock
+++ b/methods/guest/Cargo.lock
@@ -310,7 +310,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 [[package]]
 name = "risc0-circuit-rv32im"
 version = "0.16.1"
-source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
+source = "git+https://github.com/risc0/risc0?branch=release-0.16#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "anyhow",
  "log",
@@ -323,7 +323,7 @@ dependencies = [
 [[package]]
 name = "risc0-core"
 version = "0.16.1"
-source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
+source = "git+https://github.com/risc0/risc0?branch=release-0.16#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -332,7 +332,7 @@ dependencies = [
 [[package]]
 name = "risc0-zkp"
 version = "0.16.1"
-source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
+source = "git+https://github.com/risc0/risc0?branch=release-0.16#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "anyhow",
  "blake2",
@@ -353,7 +353,7 @@ dependencies = [
 [[package]]
 name = "risc0-zkvm"
 version = "0.16.1"
-source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
+source = "git+https://github.com/risc0/risc0?branch=release-0.16#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -378,7 +378,7 @@ dependencies = [
 [[package]]
 name = "risc0-zkvm-platform"
 version = "0.16.1"
-source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
+source = "git+https://github.com/risc0/risc0?branch=release-0.16#0d02111b2f84a53cf6198a0064086b281ed0f749"
 
 [[package]]
 name = "rustc-hex"

--- a/methods/guest/Cargo.lock
+++ b/methods/guest/Cargo.lock
@@ -309,8 +309,8 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.15.0"
-source = "git+https://github.com/risc0/risc0?rev=b35e1faa37fb4b60cf8dd849cf46b14d1713c881#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+version = "0.16.1"
+source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "anyhow",
  "log",
@@ -322,8 +322,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.15.0"
-source = "git+https://github.com/risc0/risc0?rev=b35e1faa37fb4b60cf8dd849cf46b14d1713c881#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+version = "0.16.1"
+source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -331,8 +331,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.15.0"
-source = "git+https://github.com/risc0/risc0?rev=b35e1faa37fb4b60cf8dd849cf46b14d1713c881#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+version = "0.16.1"
+source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "anyhow",
  "blake2",
@@ -346,13 +346,14 @@ dependencies = [
  "risc0-zkvm-platform",
  "serde",
  "sha2",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.15.0"
-source = "git+https://github.com/risc0/risc0?rev=b35e1faa37fb4b60cf8dd849cf46b14d1713c881#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+version = "0.16.1"
+source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -369,14 +370,15 @@ dependencies = [
  "risc0-zkp",
  "risc0-zkvm-platform",
  "serde",
+ "thiserror",
  "tracing",
  "typetag",
 ]
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.15.0"
-source = "git+https://github.com/risc0/risc0?rev=b35e1faa37fb4b60cf8dd849cf46b14d1713c881#b35e1faa37fb4b60cf8dd849cf46b14d1713c881"
+version = "0.16.1"
+source = "git+https://github.com/risc0/risc0?rev=0d02111b2f84a53cf6198a0064086b281ed0f749#0d02111b2f84a53cf6198a0064086b281ed0f749"
 
 [[package]]
 name = "rustc-hex"
@@ -457,6 +459,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/bin/fibonacci.rs"
 ethabi = { version = "18.0", default-features = false }
 # Directly import radium to silence warning about unused patch. See https://github.com/risc0/risc0/issues/549
 radium = "=0.7.1"
-risc0-zkvm = { git = "https://github.com/risc0/risc0", rev = "b35e1faa37fb4b60cf8dd849cf46b14d1713c881", default-features = false, features = ["std"] }
+risc0-zkvm = { git = "https://github.com/risc0/risc0", rev = "0d02111b2f84a53cf6198a0064086b281ed0f749", default-features = false, features = ["std"] }
 
 [patch.crates-io]
 radium = { git = "https://github.com/bitvecto-rs/radium", rev = "723bed5abd75994ee4b7221b8b12c9f4e77ce408" }

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/bin/fibonacci.rs"
 ethabi = { version = "18.0", default-features = false }
 # Directly import radium to silence warning about unused patch. See https://github.com/risc0/risc0/issues/549
 radium = "=0.7.1"
-risc0-zkvm = { git = "https://github.com/risc0/risc0", rev = "0d02111b2f84a53cf6198a0064086b281ed0f749", default-features = false, features = ["std"] }
+risc0-zkvm = { git = "https://github.com/risc0/risc0", branch = "release-0.16", default-features = false, features = ["std"] }
 
 [patch.crates-io]
 radium = { git = "https://github.com/bitvecto-rs/radium", rev = "723bed5abd75994ee4b7221b8b12c9f4e77ce408" }

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -17,8 +17,8 @@ clap = { version = "4.3", features = ["derive", "env"] }
 ethers = { version = "=2.0.2", features = ["rustls", "ws"] }
 ethers-signers = { version = "2.0.2", features = ["aws"] }
 hex = "0.4.3"
-risc0-build = { git = "https://github.com/risc0/risc0", rev = "b35e1faa37fb4b60cf8dd849cf46b14d1713c881", features = ["guest-list"] }
-risc0-zkvm = { git = "https://github.com/risc0/risc0.git", rev = "b35e1faa37fb4b60cf8dd849cf46b14d1713c881", default-features = false, features = ["prove"] }
+risc0-build = { git = "https://github.com/risc0/risc0", rev = "0d02111b2f84a53cf6198a0064086b281ed0f749", features = ["guest-list"] }
+risc0-zkvm = { git = "https://github.com/risc0/risc0.git", rev = "0d02111b2f84a53cf6198a0064086b281ed0f749", default-features = false, features = ["prove"] }
 tokio = { version = "1.19", features = ["full", "sync"] }
 
 [features]

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -17,8 +17,8 @@ clap = { version = "4.3", features = ["derive", "env"] }
 ethers = { version = "=2.0.2", features = ["rustls", "ws"] }
 ethers-signers = { version = "2.0.2", features = ["aws"] }
 hex = "0.4.3"
-risc0-build = { git = "https://github.com/risc0/risc0", rev = "0d02111b2f84a53cf6198a0064086b281ed0f749", features = ["guest-list"] }
-risc0-zkvm = { git = "https://github.com/risc0/risc0.git", rev = "0d02111b2f84a53cf6198a0064086b281ed0f749", default-features = false, features = ["prove"] }
+risc0-build = { git = "https://github.com/risc0/risc0", branch = "release-0.16", features = ["guest-list"] }
+risc0-zkvm = { git = "https://github.com/risc0/risc0.git", branch = "release-0.16", default-features = false, features = ["prove"] }
 tokio = { version = "1.19", features = ["full", "sync"] }
 
 [features]

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -28,7 +28,7 @@ use ethers::{
 };
 use risc0_build::GuestListEntry;
 use risc0_zkvm::{
-    Executor, ExecutorEnv, MemoryImage, Program, SessionReceipt, MEM_SIZE, PAGE_SIZE,
+    Executor, ExecutorEnv, LocalExecutor, MemoryImage, Program, SessionReceipt, MEM_SIZE, PAGE_SIZE,
 };
 
 /// Execute and prove the guest locally, on this machine, as opposed to sending
@@ -40,7 +40,7 @@ pub fn prove_locally(elf: &[u8], input: Vec<u8>, prove: bool) -> Result<Vec<u8>>
         .add_input(&input)
         .build()
         .expect("Failed to build exec env");
-    let mut exec = Executor::from_elf(env, elf).context("Failed to instantiate executor")?;
+    let mut exec = LocalExecutor::from_elf(env, elf).context("Failed to instantiate executor")?;
     let session = exec
         .run()
         .context(format!("Failed to run executor {:?}", &input))?;


### PR DESCRIPTION
Updates the zkvm dep to 0.16.1 by setting the branch to `release-0.16`. Also made the changes in .16 to use `LocalExecutor`.