### PR TITLE
refactor!: replace ethabi with alloy

### DIFF
--- a/contracts/BonsaiStarter.sol
+++ b/contracts/BonsaiStarter.sol
@@ -26,7 +26,7 @@ contract BonsaiStarter is BonsaiCallbackReceiver {
     /// @notice Cache of the results calculated by our guest program in Bonsai.
     /// @dev Using a cache is one way to handle the callback from Bonsai. Upon callback, the
     ///      information from the journal is stored in the cache for later use by the contract.
-    mapping(uint256 => uint256) public fibonacciCache;
+    mapping(uint32 => uint256) public fibonacciCache;
 
     /// @notice Image ID of the only zkVM binary to accept callbacks from.
     bytes32 public immutable fibImageId;
@@ -45,14 +45,14 @@ contract BonsaiStarter is BonsaiCallbackReceiver {
     /// @notice Returns nth number in the Fibonacci sequence.
     /// @dev The sequence is defined as 1, 1, 2, 3, 5 ... with fibonacci(0) == 1.
     ///      Only precomputed results can be returned. Call calculate_fibonacci(n) to precompute.
-    function fibonacci(uint256 n) external view returns (uint256) {
+    function fibonacci(uint32 n) external view returns (uint256) {
         uint256 result = fibonacciCache[n];
         require(result != 0, "value not available in cache");
         return result;
     }
 
     /// @notice Callback function logic for processing verified journals from Bonsai.
-    function storeResult(uint256 n, uint256 result) external onlyBonsaiCallback(fibImageId) {
+    function storeResult(uint32 n, uint256 result) external onlyBonsaiCallback(fibImageId) {
         emit CalculateFibonacciCallback(n, result);
         fibonacciCache[n] = result;
     }
@@ -61,7 +61,7 @@ contract BonsaiStarter is BonsaiCallbackReceiver {
     /// @dev This function sends the request to Bonsai through the on-chain relay.
     ///      The request will trigger Bonsai to run the specified RISC Zero guest program with
     ///      the given input and asynchronously return the verified results via the callback below.
-    function calculateFibonacci(uint256 n) external {
+    function calculateFibonacci(uint32 n) external {
         bonsaiRelay.requestCallback(
             fibImageId, abi.encode(n), address(this), this.storeResult.selector, BONSAI_CALLBACK_GAS_LIMIT
         );

--- a/contracts/BonsaiStarterLowLevel.sol
+++ b/contracts/BonsaiStarterLowLevel.sol
@@ -24,7 +24,7 @@ import {BonsaiLowLevelCallbackReceiver} from "bonsai/BonsaiLowLevelCallbackRecei
 //       or difficult to implement function to a RISC Zero guest running on Bonsai.
 contract BonsaiStarterLowLevel is BonsaiLowLevelCallbackReceiver {
     // Cache of the results calculated by our guest program in Bonsai.
-    mapping(uint256 => uint256) public fibonacciCache;
+    mapping(uint32 => uint256) public fibonacciCache;
 
     // The image id of the only binary we accept callbacks from
     bytes32 public immutable fibImageId;
@@ -39,7 +39,7 @@ contract BonsaiStarterLowLevel is BonsaiLowLevelCallbackReceiver {
     /// @notice Returns nth number in the Fibonacci sequence.
     /// @dev The sequence is defined as 1, 1, 2, 3, 5 ... with fibonacci(0) == 1.
     ///      Only precomputed results can be returned. Call calculate_fibonacci(n) to precompute.
-    function fibonacci(uint256 n) external view returns (uint256) {
+    function fibonacci(uint32 n) external view returns (uint256) {
         uint256 result = fibonacciCache[n];
         require(result != 0, "value not available in cache");
         return result;
@@ -48,7 +48,7 @@ contract BonsaiStarterLowLevel is BonsaiLowLevelCallbackReceiver {
     /// @notice Callback function logic for processing verified journals from Bonsai.
     function bonsaiLowLevelCallback(bytes calldata journal, bytes32 imageId) internal override returns (bytes memory) {
         require(imageId == fibImageId);
-        (uint256 n, uint256 result) = abi.decode(journal, (uint256, uint256));
+        (uint32 n, uint256 result) = abi.decode(journal, (uint32, uint256));
         emit CalculateFibonacciCallback(n, result);
         fibonacciCache[n] = result;
         return new bytes(0);
@@ -58,7 +58,7 @@ contract BonsaiStarterLowLevel is BonsaiLowLevelCallbackReceiver {
     /// @dev This function sends the request to Bonsai through the on-chain relay.
     ///      The request will trigger Bonsai to run the specified RISC Zero guest program with
     ///      the given input and asynchronously return the verified results via the callback below.
-    function calculateFibonacci(uint256 n) external {
+    function calculateFibonacci(uint32 n) external {
         bonsaiRelay.requestCallback(
             fibImageId, abi.encode(n), address(this), this.bonsaiLowLevelCallbackReceiver.selector, 30000
         );

--- a/methods/guest/Cargo.lock
+++ b/methods/guest/Cargo.lock
@@ -3,6 +3,48 @@
 version = 3
 
 [[package]]
+name = "alloy-primitives"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e416903084d3392ebd32d94735c395d6709415b76c7728e594d3f996f2b03e65"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "hex-literal",
+ "itoa",
+ "ruint",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7720130c58db647103587b0c39aad4e669eea261e256040301d6c7983fdbb461"
+dependencies = [
+ "dunce",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+ "syn-solidity",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa7c9a4354b1ff9f1c85adf22802af046e20e4bb55e19b9dc6ca8cbc6f7f4e5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "const-hex",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +55,12 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2"
@@ -36,7 +84,8 @@ dependencies = [
 name = "bonsai-starter-methods-guest"
 version = "0.1.0"
 dependencies = [
- "ethabi",
+ "alloy-primitives",
+ "alloy-sol-types",
  "radium",
  "risc0-zkvm",
 ]
@@ -58,7 +107,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -68,16 +117,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "const-hex"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08849ed393c907c90016652a01465a12d86361cd38ad2a7de026c56a520cc259"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "serde",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cpufeatures"
@@ -105,6 +178,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,43 +203,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "elf"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2b183d6ce6ca4cf30e3db37abf5b52568b5f9015c97d9fbdd7026aa5dcdd758"
-
-[[package]]
-name = "ethabi"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
-dependencies = [
- "ethereum-types",
- "hex",
- "sha3",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "fixed-hash",
- "primitive-types",
- "uint",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
-dependencies = [
- "byteorder",
- "rustc-hex",
- "static_assertions",
-]
 
 [[package]]
 name = "generic-array"
@@ -177,19 +236,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "keccak"
-version = "0.1.4"
+name = "hex-literal"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
-dependencies = [
- "cpufeatures",
-]
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "libc"
@@ -217,7 +285,7 @@ checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -227,6 +295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -242,14 +311,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
-name = "primitive-types"
-version = "0.12.1"
+name = "ppv-lite86"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
-dependencies = [
- "fixed-hash",
- "uint",
-]
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
@@ -258,6 +323,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "unarray",
 ]
 
 [[package]]
@@ -275,10 +355,38 @@ version = "0.7.1"
 source = "git+https://github.com/bitvecto-rs/radium?rev=723bed5abd75994ee4b7221b8b12c9f4e77ce408#723bed5abd75994ee4b7221b8b12c9f4e77ce408"
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "risc0-binfmt"
@@ -364,10 +472,39 @@ version = "0.17.0"
 source = "git+https://github.com/risc0/risc0?rev=da5bc39089c6dba8b03510837f1c7363ed3cc8b7#da5bc39089c6dba8b03510837f1c7363ed3cc8b7"
 
 [[package]]
-name = "rustc-hex"
-version = "2.1.0"
+name = "ruint"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+checksum = "95294d6e3a6192f3aabf91c38f56505a625aa495533442744185a36d75a790c4"
+dependencies = [
+ "proptest",
+ "rand",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
@@ -386,7 +523,7 @@ checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -401,26 +538,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
-dependencies = [
- "digest",
- "keccak",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -431,6 +563,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397f229dc34c7b8231b6ef85502f9ca4e3425b8625e6d403bb74779e6b1917b5"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -453,7 +606,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -469,22 +622,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
-name = "uint"
-version = "0.9.5"
+name = "unarray"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -497,3 +650,9 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -8,7 +8,8 @@ name = "fibonacci"
 path = "src/bin/fibonacci.rs"
 
 [dependencies]
-ethabi = { version = "18.0", default-features = false }
+alloy-sol-types = { version = "0.3.2", default-features = false }
+alloy-primitives = { version = "0.3.2", default-features = false }
 # Directly import radium to silence warning about unused patch. See https://github.com/risc0/risc0/issues/549
 radium = "=0.7.1"
 risc0-zkvm = { git = "https://github.com/risc0/risc0", rev = "da5bc39089c6dba8b03510837f1c7363ed3cc8b7", default-features = false, features = ["std"] }

--- a/methods/guest/src/bin/fibonacci.rs
+++ b/methods/guest/src/bin/fibonacci.rs
@@ -34,7 +34,7 @@ fn main() {
     // Read data sent from the application contract.
     let mut input_bytes = Vec::<u8>::new();
     env::stdin().read_to_end(&mut input_bytes).unwrap();
-    // Type array passed to `ethabi::decode_whole` should match the types encoded in
+    // Type use with `sol!` macro should match the types encoded in
     // the application contract.
     let (n,) = <sol!(tuple(uint32,))>::decode_params(&input_bytes, true).unwrap();
 

--- a/methods/guest/src/bin/fibonacci.rs
+++ b/methods/guest/src/bin/fibonacci.rs
@@ -16,14 +16,15 @@
 
 use std::io::Read;
 
-use ethabi::{ethereum_types::U256, ParamType, Token};
+use alloy_primitives::U256;
+use alloy_sol_types::{sol, SolType};
 use risc0_zkvm::guest::env;
 
 risc0_zkvm::guest::entry!(main);
 
 fn fibonacci(n: U256) -> U256 {
-    let (mut prev, mut curr) = (U256::one(), U256::one());
-    for _ in 2..=n.as_u32() {
+    let (mut prev, mut curr) = (U256::from(1), U256::from(1));
+    for _ in 2..=n.try_into().unwrap() {
         (prev, curr) = (curr, prev + curr);
     }
     curr
@@ -35,13 +36,14 @@ fn main() {
     env::stdin().read_to_end(&mut input_bytes).unwrap();
     // Type array passed to `ethabi::decode_whole` should match the types encoded in
     // the application contract.
-    let input = ethabi::decode_whole(&[ParamType::Uint(256)], &input_bytes).unwrap();
-    let n: U256 = input[0].clone().into_uint().unwrap();
+    let (n,) = <sol!(tuple(uint256,))>::decode_params(&input_bytes, true).unwrap();
 
     // Run the computation.
     let result = fibonacci(n);
 
     // Commit the journal that will be received by the application contract.
     // Encoded types should match the args expected by the application callback.
-    env::commit_slice(&ethabi::encode(&[Token::Uint(n), Token::Uint(result)]));
+    env::commit_slice(&<sol!(tuple(uint256, uint256))>::encode_params(&(
+        n, result,
+    )));
 }

--- a/methods/guest/src/bin/fibonacci.rs
+++ b/methods/guest/src/bin/fibonacci.rs
@@ -22,9 +22,9 @@ use risc0_zkvm::guest::env;
 
 risc0_zkvm::guest::entry!(main);
 
-fn fibonacci(n: U256) -> U256 {
+fn fibonacci(n: u32) -> U256 {
     let (mut prev, mut curr) = (U256::from(1), U256::from(1));
-    for _ in 2..=n.try_into().unwrap() {
+    for _ in 2..=n {
         (prev, curr) = (curr, prev + curr);
     }
     curr
@@ -36,14 +36,12 @@ fn main() {
     env::stdin().read_to_end(&mut input_bytes).unwrap();
     // Type array passed to `ethabi::decode_whole` should match the types encoded in
     // the application contract.
-    let (n,) = <sol!(tuple(uint256,))>::decode_params(&input_bytes, true).unwrap();
+    let (n,) = <sol!(tuple(uint32,))>::decode_params(&input_bytes, true).unwrap();
 
     // Run the computation.
     let result = fibonacci(n);
 
     // Commit the journal that will be received by the application contract.
     // Encoded types should match the args expected by the application callback.
-    env::commit_slice(&<sol!(tuple(uint256, uint256))>::encode_params(&(
-        n, result,
-    )));
+    env::commit_slice(&<sol!(tuple(uint32, uint256))>::encode_params(&(n, result)));
 }


### PR DESCRIPTION
Given that ethabi is unmaintained and a bit unwieldy to use, I figured I'd open a PR to suggest updating it to [alloy](https://github.com/alloy-rs/core) since it seems to be the most promising alternative.

I also changed the input type to a uint32, since the contract previously [panicked when above the 32 bit range anyway](https://docs.rs/ethereum-types/latest/ethereum_types/struct.U256.html#method.as_u32), but I can revert https://github.com/risc0/bonsai-foundry-template/commit/f41123ef5700b3165deb6e3662a216930d21f532 and https://github.com/risc0/bonsai-foundry-template/commit/4f45e5b3a6ceadfd49b6b334cd48e34f5e536557 if this is intentional for some reason.

~~Edit: moving to draft until I update the example utilities~~

Edit2: I didn't notice the ethers dependency with the Ethereum relay client. It might not be worth bringing this PR in, and very opinionated to mix two abi encoding libraries, but it seems reasonable in this case since the risc0 program is isolated and the main DevX barrier to entry. Feel free to close if not wanted as this is very opinionated.