### PR TITLE
fix: Update and fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,39 @@
-# Start from rust template
-FROM rust
+FROM ubuntu:20.04@sha256:3246518d9735254519e1b2ff35f95686e4a5011c90c85344c1f38df7bae9dd37
 
-# Install Foundry
-RUN cargo install --git https://github.com/foundry-rs/foundry --profile local --force foundry-cli anvil chisel
+# Install Rust and build dependencies
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends git build-essential ca-certificates clang curl libssl-dev pkg-config ssh
+RUN curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL 'https://sh.rustup.rs' | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install rust toolchain
-COPY rust-toolchain.toml .
-RUN rustup toolchain install .
+WORKDIR /root
+
+# Install foundry through foundryup
+RUN curl -L https://foundry.paradigm.xyz | bash; \
+    /bin/bash -c 'source $HOME/.bashrc'; \
+    /root/.foundry/bin/foundryup
+ENV PATH "$PATH:/root/.foundry/bin/"
+RUN echo "export PATH=${PATH}" >> $HOME/.bashrc;
+
+# Alternatively, install from source
+# RUN cargo install --git https://github.com/foundry-rs/foundry --profile local forge cast chisel anvil
 
 # Copy source code
-COPY . .
+COPY . /app
+WORKDIR /app
+
+# Install rust toolchain
+RUN rustup toolchain install .
 
 # Update github host
 RUN mkdir -p /root/.ssh && ssh-keyscan github.com > ~/.ssh/known_hosts
 
 # Build solidity code
 RUN forge build
+
+# Install risc0 toolchain
+RUN cargo install cargo-risczero
+RUN cargo risczero install
 
 # Build rust code
 RUN --mount=type=ssh  \


### PR DESCRIPTION
Dockerfile was broken for a few reasons:
- Copying source code fails in root directory (not sure how this ever worked before)
- Outdated foundry install (also switched default to just using foundryup to be faster)
- risc0 toolchain wasn't installed
  - I just used the same base image as the risc0 dockerfile, to ensure compatibility

doesn't matter to me if this is pulled in, just made these updates for my own use and figured I'd upstream