### PR TITLE
Enforce BONSAI_API_KEY usage

### DIFF
--- a/deployment-guide.md
+++ b/deployment-guide.md
@@ -55,7 +55,7 @@ It also provides an SDK in Rust that can be used to interact with it. You can ch
 1. Send a callback request directly to the Relay by running:
 
     ```bash
-    cargo run --example offchain_request "$APP_ADDRESS" 10
+    BONSAI_API_KEY="YOUR_API_KEY_OR_EMPTY_IF_DEV_MODE" cargo run --example offchain_request "$APP_ADDRESS" 10
     ```
 
 2. Check the relayed result:
@@ -156,7 +156,7 @@ You now have a deployment on a testnet that you can interact with sending either
 1. Send a callback request directly to the Relay by running:
 
     ```bash
-    cargo run --example offchain_request "$APP_ADDRESS" 10
+    BONSAI_API_KEY="YOUR_API_KEY_OR_EMPTY_IF_DEV_MODE" cargo run --example offchain_request "$APP_ADDRESS" 10
     ```
 
 2. Check the relayed result:

--- a/relay/examples/offchain_request.rs
+++ b/relay/examples/offchain_request.rs
@@ -40,7 +40,7 @@ struct Args {
     bonsai_relay_api_url: String,
 
     /// Bonsai API key. Used by the relay to send requests to the Bonsai proving
-    /// service. Defaults to empty, providing no authentication.
+    /// service. Can be set to an empty string when DEV_MODE is enabled.
     #[arg(long, env)]
     bonsai_api_key: Option<String>,
 }

--- a/relay/examples/offchain_request.rs
+++ b/relay/examples/offchain_request.rs
@@ -59,8 +59,8 @@ async fn main() -> anyhow::Result<()> {
     }
     // initialize a relay client
     let relay_client = Client::from_parts(
-        args.bonsai_relay_api_url.clone(), // Set BONSAI_API_URL or replace this line.
-        args.bonsai_api_key.unwrap(),      // Set BONSAI_API_KEY or replace this line.
+        args.bonsai_relay_api_url.clone(),
+        args.bonsai_api_key.unwrap(),
     )
     .context("Failed to initialize the relay client")?;
 

--- a/tests/BonsaiStarter.t.sol
+++ b/tests/BonsaiStarter.t.sol
@@ -27,10 +27,7 @@ contract BonsaiStarterTest is BonsaiTest {
     function testOffChainMock() public {
         bytes32 imageId = queryImageId("FIBONACCI");
         // Deploy a new starter instance
-        BonsaiStarter starter = new BonsaiStarter(
-            IBonsaiRelay(bonsaiRelay),
-            imageId
-        );
+        BonsaiStarter starter = new BonsaiStarter(IBonsaiRelay(bonsaiRelay), imageId);
 
         // Anticipate a callback invocation on the starter contract
         vm.expectCall(address(starter), abi.encodeWithSelector(BonsaiStarter.storeResult.selector));
@@ -48,10 +45,7 @@ contract BonsaiStarterTest is BonsaiTest {
     // Test the BonsaiStarter contract by mocking an on-chain callback request
     function testOnChainMock() public {
         // Deploy a new starter instance
-        BonsaiStarter starter = new BonsaiStarter(
-            IBonsaiRelay(bonsaiRelay),
-            queryImageId("FIBONACCI")
-        );
+        BonsaiStarter starter = new BonsaiStarter(IBonsaiRelay(bonsaiRelay), queryImageId("FIBONACCI"));
 
         // Anticipate an on-chain callback request to the relay
         vm.expectCall(address(bonsaiRelay), abi.encodeWithSelector(IBonsaiRelay.requestCallback.selector));

--- a/tests/BonsaiStarterLowLevel.t.sol
+++ b/tests/BonsaiStarterLowLevel.t.sol
@@ -25,9 +25,7 @@ contract BonsaiStarterLowLevelTest is BonsaiTest {
 
     function testMockLowLevelCall() public {
         // Deploy a new starter instance
-        BonsaiStarterLowLevel starter = new BonsaiStarterLowLevel(
-            IBonsaiRelay(bonsaiRelay),
-            queryImageId('FIBONACCI'));
+        BonsaiStarterLowLevel starter = new BonsaiStarterLowLevel(IBonsaiRelay(bonsaiRelay), queryImageId("FIBONACCI"));
 
         // Anticipate a callback request to the relay
         vm.expectCall(address(bonsaiRelay), abi.encodeWithSelector(IBonsaiRelay.requestCallback.selector));


### PR DESCRIPTION
Adds an error message when a BONSAI_API_KEY is not defined when using the off-chain example