### PR TITLE
Add murky to remappings

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,4 @@
+murky/=lib/murky/
 murky_differential_testing/=lib/murky/differential_testing/
 forge-std/=lib/forge-std/src/
 openzeppelin/=lib/openzeppelin-contracts/


### PR DESCRIPTION
As far as I've understood, remappings of `risc0-ethereum` should be replicated to the foundry template as well, so `murky` has been added to that.

Closes https://github.com/risc0/risc0-ethereum/issues/25 