### PR TITLE
Bump risc0-ethereum dependencies to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ hex = { version = "0.4" }
 log = { version = "0.4" }
 methods = { path = "./methods" }
 risc0-build = { version = "0.21", features = ["docker"] }
-risc0-build-ethereum = { git = "https://github.com/risc0/risc0-ethereum", branch = "release-0.8" }
-risc0-ethereum-contracts = { git = "https://github.com/risc0/risc0-ethereum", branch = "release-0.8" }
+risc0-build-ethereum = { git = "https://github.com/risc0/risc0-ethereum", branch = "release-0.9" }
+risc0-ethereum-contracts = { git = "https://github.com/risc0/risc0-ethereum", branch = "release-0.9" }
 risc0-zkvm = { version = "0.21", default-features = false }
 risc0-zkp = { version = "0.21", default-features = false }
 serde = { version = "1.0", features = ["derive", "std"] }


### PR DESCRIPTION
Version 0.9 of the crates in the `risc0-ethereum` repository is being released. The major feature is a new library to make Ethereum view calls within the guest.

This PR bumps the reference to the `risc0-ethereum` repo to the `release-0.9` branch.

https://github.com/risc0/risc0-ethereum
