### PR TITLE
Fix Documentation Duplication and Improve Clarity in CLI Argument Descriptions

### DIFF
--- a/apps/src/bin/publisher.rs
+++ b/apps/src/bin/publisher.rs
@@ -42,11 +42,11 @@ struct Args {
     #[clap(long)]
     chain_id: u64,
 
-    /// Ethereum Node endpoint.
+    /// Private key for signing Ethereum transactions.
     #[clap(long, env)]
     eth_wallet_private_key: PrivateKeySigner,
 
-    /// Ethereum Node endpoint.
+    /// Ethereum Node RPC URL.
     #[clap(long)]
     rpc_url: Url,
 


### PR DESCRIPTION
Removed redundancy (both had "Ethereum Node endpoint.").
Improved clarity (each argument now has a distinct purpose).
Better readability (concise & structured descriptions).
